### PR TITLE
Fixed type-o in the name official statistics

### DIFF
--- a/PxAPI-2.yml
+++ b/PxAPI-2.yml
@@ -851,7 +851,7 @@ components:
         aggregationAllowed:
           type: boolean
           description: If all content of the table can be aggregated.
-        officalStatistics:
+        officialStatistics:
           type: boolean
           description: A marker if the table is a part of the national official statistics.
         subjectCode:


### PR DESCRIPTION
Fixed the type-o for the property official statistics

See issue https://github.com/PxTools/PxWebApi/issues/93