### PR TITLE
Same spelling for license

### DIFF
--- a/PxAPI-2.yml
+++ b/PxAPI-2.yml
@@ -866,7 +866,7 @@ components:
           type: string
           description: The name of the organization responsible for the table.
           example: Statistics Sweden
-        licence:
+        license:
           type: string
           description: A copyright statement for the data it could also be SPDX (https://spdx.org/licenses/) identifier
           example: CC0-1.0


### PR DESCRIPTION
changed the spelling of license to be consistent in the spec. By using the american spelling.

See issue https://github.com/PxTools/PxWebApi/issues/93