### PR TITLE
Extracted enum for property class to a schema

### DIFF
--- a/PxAPI-2.yml
+++ b/PxAPI-2.yml
@@ -1565,11 +1565,12 @@ components:
             - '2.0'
           default: '2.0'      
         class:
-          description: "Is always dataset"
-          type: string
-          enum:
-            - dataset
-          default: dataset
+          "$ref": "#/components/schemas/ClassType"
+          # description: "Is always dataset"
+          # type: string
+          # enum:
+          #   - dataset
+          # default: dataset
         href:
           "$ref": "#/components/schemas/href"
         label:
@@ -1648,7 +1649,14 @@ components:
         - id
         - size
         - dimension
-                   
+
+    ClassType:
+      description: "Is always dataset"
+      type: string
+      enum:
+        - dataset
+      default: dataset                   
+
   responses:
     ErrorResponse429:
       description: Error respsone for 429


### PR DESCRIPTION
Small fix for overcoming problem when generating type for with openapi-typescript-codegen for enums with reserved words

There is a similar issue that has been fix https://github.com/ferdikoomen/openapi-typescript-codegen/issues/1230 in openapi-typescript-codegen but we still get an error.

Problem is that a enum type is generated having the reserved word. If is to extract the enum type in its own schema.