### PR TITLE
Representing a value hierarchy

### DIFF
--- a/PxAPI-2.yml
+++ b/PxAPI-2.yml
@@ -1111,6 +1111,10 @@ components:
         label:
           type: string
           description: A Textual name for the value
+        parentCode:
+          type: string
+          description: The code of the parent value
+          nullable: true
         notes: 
           type: array
           description: Optional notes that are associated with the value


### PR DESCRIPTION
Added an optional `parentCode` property that can be used to show a hierarchical structure between values in a codelist