### PR TITLE
Added outputFormatParams in post data endpoint

### DIFF
--- a/PxAPI-2.yml
+++ b/PxAPI-2.yml
@@ -273,42 +273,8 @@ paths:
               ]
           style: deepObject
           explode: true    
-        - in: query
-          name: outputFormat
-          schema:
-            type: string
-            enum: 
-              - px
-              - json-stat2
-              - csv
-              - xlsx
-              - html
-              - json-px
-              - parquet
-        - in: query
-          name: outputFormatParams
-          required: false
-          schema:
-            type: array
-            items:
-              type: string
-              enum: 
-                - UseCodes
-                - UseTexts
-                - UseCodesAndTexts
-                - IncludeTitle
-                - SeparatorTab
-                - SeparatorSpace
-                - SeparatorSemicolon
-              description: |
-                Parameters for the output format. 
-                * UseCodes: Can not be combined with UseTexts and UseCodesAndTexts. And only applicable for csv, html and xlsx output format.
-                * UseTexts: Can not be combined with UsedCodes and UseCodesAndTexts. And only applicable for csv, html and xlsx output format.
-                * UseCodesAndTexts: Can not be combined with UseCodess and UseTexts. And only applicable for csv, html and xlsx output format.
-                * IncludeTitle: Only applicable for csv, html and xlsx output format.
-                * SeparatorTab: Can not be combined with SeparatorSpace and SeparatorSemicolon. And only applicable for csv output format.
-                * SeparatorSpace: Can not be combined with SeparatorTab and SeparatorSemicolon. And only applicable for csv output format.
-                * SeparatorSemicolon: Can not be combined with SeparatorTab and SeparatorSpace. And only applicable for csv output format.
+        - $ref: '#/components/parameters/outputFormat'
+        - $ref: '#/components/parameters/outputFormatParams'
         - in: query
           name: heading
           style: form
@@ -364,10 +330,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/lang'
         - $ref: '#/components/parameters/id'
-        - in: query
-          name: outputFormat
-          schema:
-            type: string
+        - $ref: '#/components/parameters/outputFormat'
+        - $ref: '#/components/parameters/outputFormatParams'
       requestBody:
         description: A selection
         content:
@@ -509,6 +473,44 @@ components:
       required: false
       schema:
         $ref: '#/components/schemas/MetadataOutputFormatType'
+    outputFormat:
+      name: outputFormat
+      in: query
+      schema:
+        type: string
+        enum: 
+          - px
+          - json-stat2
+          - csv
+          - xlsx
+          - html
+          - json-px
+          - parquet
+    outputFormatParams:
+      name: outputFormatParams
+      in: query
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
+          enum: 
+            - UseCodes
+            - UseTexts
+            - UseCodesAndTexts
+            - IncludeTitle
+            - SeparatorTab
+            - SeparatorSpace
+            - SeparatorSemicolon
+          description: |
+            Parameters for the output format. 
+            * UseCodes: Can not be combined with UseTexts and UseCodesAndTexts. And only applicable for csv, html and xlsx output format.
+            * UseTexts: Can not be combined with UsedCodes and UseCodesAndTexts. And only applicable for csv, html and xlsx output format.
+            * UseCodesAndTexts: Can not be combined with UseCodess and UseTexts. And only applicable for csv, html and xlsx output format.
+            * IncludeTitle: Only applicable for csv, html and xlsx output format.
+            * SeparatorTab: Can not be combined with SeparatorSpace and SeparatorSemicolon. And only applicable for csv output format.
+            * SeparatorSpace: Can not be combined with SeparatorTab and SeparatorSemicolon. And only applicable for csv output format.
+            * SeparatorSemicolon: Can not be combined with SeparatorTab and SeparatorSpace. And only applicable for csv output format.
   schemas:
     VariablesSelection:
       type: object

--- a/src/PxWeb.Api2.Server/Controllers/TableApi.cs
+++ b/src/PxWeb.Api2.Server/Controllers/TableApi.cs
@@ -141,6 +141,7 @@ namespace PxWeb.Api2.Server.Controllers
         /// <param name="id">Id</param>
         /// <param name="lang">The language if the default is not what you want.</param>
         /// <param name="outputFormat"></param>
+        /// <param name="outputFormatParams"></param>
         /// <param name="variablesSelection">A selection</param>
         /// <response code="200">Success</response>
         /// <response code="400">Error response for 400</response>
@@ -157,7 +158,7 @@ namespace PxWeb.Api2.Server.Controllers
         [SwaggerResponse(statusCode: 403, type: typeof(Problem), description: "Error response for 403")]
         [SwaggerResponse(statusCode: 404, type: typeof(Problem), description: "Error response for 404")]
         [SwaggerResponse(statusCode: 429, type: typeof(Problem), description: "Error response for 429")]
-        public abstract IActionResult GetTableDataByPost([FromRoute (Name = "id")][Required]string id, [FromQuery (Name = "lang")]string? lang, [FromQuery (Name = "outputFormat")]string? outputFormat, [FromBody]VariablesSelection? variablesSelection);
+        public abstract IActionResult GetTableDataByPost([FromRoute (Name = "id")][Required]string id, [FromQuery (Name = "lang")]string? lang, [FromQuery (Name = "outputFormat")]string? outputFormat, [FromQuery (Name = "outputFormatParams")]List<string>? outputFormatParams, [FromBody]VariablesSelection? variablesSelection);
 
         /// <summary>
         /// Get all Tables.


### PR DESCRIPTION
The POST data endopoint was missing the new outputFormatParams parameter which has been added.
Also the outputFormat and the outputFormatParam was moved to the parameters section so that they can be recused from different endpoints.