### PR TITLE
Added organization on contacts and language parameter on saved query  data endpoint

### DIFF
--- a/PxAPI-2.yml
+++ b/PxAPI-2.yml
@@ -426,6 +426,7 @@ paths:
       tags:
         - Saved Queries
       parameters:
+        - $ref: "#/components/parameters/lang"
         - $ref: "#/components/parameters/id"
         - $ref: "#/components/parameters/outputFormat"
         - $ref: "#/components/parameters/outputFormatParams"

--- a/PxAPI-2.yml
+++ b/PxAPI-2.yml
@@ -1339,6 +1339,9 @@ components:
         name:
           type: string
           example: Inga Svensson
+        organization:
+          type: string
+          example: Statistics Sweden
         phone:
           type: string
           example: "+46101111111"

--- a/src/PxWeb.Api2.Server.Models/Contact.cs
+++ b/src/PxWeb.Api2.Server.Models/Contact.cs
@@ -34,6 +34,13 @@ namespace PxWeb.Api2.Server.Models
         public string? Name { get; set; }
 
         /// <summary>
+        /// Gets or Sets Organization
+        /// </summary>
+        /* <example>Statistics Sweden</example> */
+        [DataMember(Name="organization", EmitDefaultValue=false)]
+        public string? Organization { get; set; }
+
+        /// <summary>
         /// Gets or Sets Phone
         /// </summary>
         /* <example>+46101111111</example> */
@@ -64,6 +71,7 @@ namespace PxWeb.Api2.Server.Models
             var sb = new StringBuilder();
             sb.Append("class Contact {\n");
             sb.Append("  Name: ").Append(Name).Append("\n");
+            sb.Append("  Organization: ").Append(Organization).Append("\n");
             sb.Append("  Phone: ").Append(Phone).Append("\n");
             sb.Append("  Mail: ").Append(Mail).Append("\n");
             sb.Append("  Raw: ").Append(Raw).Append("\n");
@@ -109,6 +117,11 @@ namespace PxWeb.Api2.Server.Models
                     Name.Equals(other.Name)
                 ) && 
                 (
+                    Organization == other.Organization ||
+                    Organization != null &&
+                    Organization.Equals(other.Organization)
+                ) && 
+                (
                     Phone == other.Phone ||
                     Phone != null &&
                     Phone.Equals(other.Phone)
@@ -137,6 +150,8 @@ namespace PxWeb.Api2.Server.Models
                 // Suitable nullity checks etc, of course :)
                     if (Name != null)
                     hashCode = hashCode * 59 + Name.GetHashCode();
+                    if (Organization != null)
+                    hashCode = hashCode * 59 + Organization.GetHashCode();
                     if (Phone != null)
                     hashCode = hashCode * 59 + Phone.GetHashCode();
                     if (Mail != null)

--- a/src/PxWeb.Api2.Server/Controllers/SavedQueriesApi.cs
+++ b/src/PxWeb.Api2.Server/Controllers/SavedQueriesApi.cs
@@ -66,6 +66,7 @@ namespace PxWeb.Api2.Server.Controllers
         /// Retrieves the data by running the saved query.
         /// </summary>
         /// <param name="id">Id</param>
+        /// <param name="lang">The language if the default is not what you want.</param>
         /// <param name="outputFormat"></param>
         /// <param name="outputFormatParams"></param>
         /// <response code="200">Success</response>
@@ -82,6 +83,6 @@ namespace PxWeb.Api2.Server.Controllers
         [SwaggerResponse(statusCode: 403, type: typeof(Problem), description: "Error response for 403")]
         [SwaggerResponse(statusCode: 404, type: typeof(Problem), description: "Error response for 404")]
         [SwaggerResponse(statusCode: 429, type: typeof(Problem), description: "Error response for 429")]
-        public abstract IActionResult RunSaveQuery([FromRoute (Name = "id")][Required]string id, [FromQuery (Name = "outputFormat")]OutputFormatType? outputFormat, [FromQuery (Name = "outputFormatParams")]List<OutputFormatParamType>? outputFormatParams);
+        public abstract IActionResult RunSaveQuery([FromRoute (Name = "id")][Required]string id, [FromQuery (Name = "lang")]string? lang, [FromQuery (Name = "outputFormat")]OutputFormatType? outputFormat, [FromQuery (Name = "outputFormatParams")]List<OutputFormatParamType>? outputFormatParams);
     }
 }


### PR DESCRIPTION
Added a optional `organization` property on the `contact` structure.

Added a `lang` query string parameter that can be used to override the language of a saved query.

